### PR TITLE
replace persistence

### DIFF
--- a/kubernetes/apps/default/nginx-static/app/helmrelease.yaml
+++ b/kubernetes/apps/default/nginx-static/app/helmrelease.yaml
@@ -89,11 +89,12 @@ spec:
           - path: /etc/nginx/nginx.conf
             subPath: nginx.conf  # Ensure this matches the key name in the ConfigMap
             readOnly: true
-
-      var/log/nginx:
+      var:
         type: emptyDir
-      var/cache/nginx:
-        type: emptyDir
-      var/run:
-        type: emptyDir
-
+        globalMounts:
+          - path: /var/log/nginx
+            subPath: nginx
+          - path: /var/cache/nginx
+            subPath: nginx
+          - path: /var/run
+            subPath: run


### PR DESCRIPTION
fixes:

> default                 nginx-static                      8d      False   Helm upgrade failed for release default/nginx-static with chart app-template@3.5.1: cannot patch "nginx-static" with kind Deployment: Deployment.apps "nginx-static" is invalid: [spec.template.spec.volumes[1].name: Invalid value: "var/cache/nginx": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'), spec.template.spec.volumes[2].name: Invalid value: "var/log/nginx": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'), spec.template.spec.volumes[3].name: Invalid value: "var/run": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'), spec.template.spec.containers[0].volumeMounts[1].name: Not found: "var/cache/nginx", spec.template.spec.containers[0].volumeMounts[2].name: Not found: "var/log/nginx", spec.template.spec.containers[0].volumeMounts[3].name: Not found: "var/run"]
