### PR TITLE
Added minecraft server kustomization

### DIFF
--- a/kubernetes/apps/minecraft-server/kustomization.yml
+++ b/kubernetes/apps/minecraft-server/kustomization.yml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: minecraft-server
+resources:
+- minecraft/statefulset.yml
+- minecraft/service.yml
+- minecraft/config.yml

--- a/kubernetes/apps/minecraft-server/minecraft/config.yml
+++ b/kubernetes/apps/minecraft-server/minecraft/config.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: minecraft-server-config
+data:
+  EULA: "TRUE"
+  VERSION: "1.21.3"
+  MC_PORT: "25565"
+  MEMORY: "4096M"
+  MOTD: "Honk"
+  OVERRIDE_ICON: "true"
+  OPS: |-
+    c251e7d8-ac28-4589-83c9-54b42cd2f878
+  ICON: "https://opengameart.org/sites/default/files/Pixel_Bird_png.png"
+  WORLD: "https://www.curseforge.com/api/v1/mods/674973/files/6194809/download"
+  TZ: "Europe/Vienna"

--- a/kubernetes/apps/minecraft-server/minecraft/service.yml
+++ b/kubernetes/apps/minecraft-server/minecraft/service.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: minecraft-server
+  name: minecraft-server
+spec:
+  ports:
+    - name: minecraft
+      port: 25565
+      targetPort: 25565
+  type: NodePort
+  selector:
+    server: minecraft-server

--- a/kubernetes/apps/minecraft-server/minecraft/statefulset.yml
+++ b/kubernetes/apps/minecraft-server/minecraft/statefulset.yml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: minecraft-server
+spec:
+  replicas: 1
+  serviceName: minecraft-server
+  selector:
+    matchLabels:
+      server: minecraft-server
+  template:
+    metadata:
+      labels:
+        server: minecraft-server
+    spec:
+      containers:
+        - name: minecraft-server
+          envFrom:
+            - configMapRef:
+                name: minecraft-server-config
+          env: []
+          image: itzg/minecraft-server:latest
+          stdin: true
+          tty: true
+          volumeMounts:
+            - mountPath: /data
+              name: data
+          resources:
+            requests:
+              cpu: 150m
+          livenessProbe:
+            exec:
+              command: ["mc-health"]
+            initialDelaySeconds: 120
+            periodSeconds: 60
+          readinessProbe:
+            exec:
+              command: ["mc-health"]
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 12
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Gi


### PR DESCRIPTION
# Info
The server kustomization is under kubernetes/apps/minecraft-server.
It uses a statefulset to run the server, and a service that connects to it.
The image is very flexible and can be configured to run mods, plugins and all kinds of stuff.
The statefulset has a data volume, which holds the server directory.
It is currently configured to automatically set up the gamemode Lexy requested - [OneBlock](https://www.curseforge.com/minecraft/worlds/oneblock-reborn/download/6194809) for MC 1.21.3

### envs
The environment variables are taken from the ConfigMap in config.yml. See https://setupmc.com/java-server/ for additional environment variables.
If you want to have OP ingame, you can add your UID in a new line under OPS.

Note: The MC_PORT environment variable is required due to a bug with the way stuff is automatically configured. If not set, it defaults to `tcp://<ip>:<port>` which the healthcheck program fails to parse.

resolves #408 