### PR TITLE
Revert "feat(container): update image ghcr.io/dragonflydb/operator ( v1.4.0 ➔ v1.5.0 )"

### DIFF
--- a/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
+++ b/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dragonflydb/operator
-              tag: v1.5.0@sha256:2ceb0128302cd7756b743cc5d56ec9479fb08163b5c563897045a4e5e1555f02
+              tag: v1.4.0@sha256:b6ceebe49d4687a4fc3e485724a0cfcf0ca2dfba1d5508375543b8db46a66fc1
             command: ["/manager"]
             args:
               - --health-probe-bind-address=:8081


### PR DESCRIPTION
Reverts RonaldPhilipsen/home-ops#1706 due to https://github.com/dragonflydb/dragonfly-operator/issues/488